### PR TITLE
Increase tone sample limit

### DIFF
--- a/app/api/tone-sample/route.ts
+++ b/app/api/tone-sample/route.ts
@@ -5,7 +5,7 @@ import { authOptions }     from '@/app/api/auth/[...nextauth]/route';
 import { supabaseAdmin }   from '@/lib/supabaseAdmin';
 
 // 無料ユーザーの口調サンプル上限
-const FREE_USER_TONE_SAMPLE_MAX = 1000;
+const FREE_USER_TONE_SAMPLE_MAX = 2000;
 
 export async function POST(req: Request) {
   // 1. 認証チェック

--- a/app/components/ToneSampleModal.tsx
+++ b/app/components/ToneSampleModal.tsx
@@ -72,6 +72,7 @@ export default function ToneSampleModal({
         </p>
         <textarea
           rows={8}
+          maxLength={maxLength}
           className="w-full text-sm p-2 border border-slate-300 rounded-md focus:ring-1 focus:ring-blue-500 focus:border-blue-500 mb-2 resize-y"
           placeholder="ここに口調サンプルを入力..."
           value={sampleText}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ import ToneSampleModal from "./components/ToneSampleModal"; // ★ インポー�
 // }
 
 // 無料ユーザーの口調サンプルの最大文字数 (API側と合わせる)
-const FREE_USER_TONE_SAMPLE_MAX_LENGTH = 1000;
+const FREE_USER_TONE_SAMPLE_MAX_LENGTH = 2000;
 
 export default function Home() {
   const [url, setUrl] = useState("");


### PR DESCRIPTION
## Summary
- allow up to 2000 chars for tone sample
- enforce limit via `maxLength` attribute

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68569dd63e1c8321a64506a5eb93344b