### PR TITLE
Add Satomasahiko tone

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,7 +52,7 @@ export default function Home() {
 
 
   const handleSummarize = async (
-    selectedTone: "casual" | "formal" | "custom"
+    selectedTone: "casual" | "formal" | "custom" | "satomasahiko"
   ) => {
     if (!url) {
       alert("URLを入力してください");
@@ -298,7 +298,7 @@ export default function Home() {
           />
         </div>
 
-        <div className={`grid gap-3 mb-4 ${status === 'authenticated' ? 'grid-cols-3' : 'grid-cols-2'}`}>
+        <div className={`grid gap-3 mb-4 ${status === 'authenticated' ? 'grid-cols-4' : 'grid-cols-3'}`}>
           <button
             onClick={() => handleSummarize("casual")}
             className={`w-full px-4 py-2.5 bg-sky-500 text-white text-base rounded-md font-medium hover:bg-sky-600 active:bg-sky-700 transition-colors focus:outline-none focus:ring-1 focus:ring-sky-400 focus:ring-offset-1 ${
@@ -316,6 +316,15 @@ export default function Home() {
             disabled={isLoading}
           >
             {isLoading ? "処理中..." : "フォーマル"}
+          </button>
+          <button
+            onClick={() => handleSummarize("satomasahiko")}
+            className={`w-full px-4 py-2.5 bg-pink-500 text-white text-base rounded-md font-medium hover:bg-pink-600 active:bg-pink-700 transition-colors focus:outline-none focus:ring-1 focus:ring-pink-400 focus:ring-offset-1 ${
+              isLoading ? "opacity-50 cursor-not-allowed" : ""
+            }`}
+            disabled={isLoading}
+          >
+            {isLoading ? "処理中..." : "佐藤正彦風"}
           </button>
           {status === "authenticated" && (
             <button

--- a/lib/buildMessages.ts
+++ b/lib/buildMessages.ts
@@ -1,7 +1,7 @@
 import type { ChatCompletionRequestMessage } from 'openai'
 
 export function buildMessages(
-  tone: 'custom' | 'formal' | 'casual',
+  tone: 'custom' | 'formal' | 'casual' | 'satomasahiko',
   articleContent: string,
   toneSample?: string
 ): ChatCompletionRequestMessage[] {
@@ -12,6 +12,18 @@ export function buildMessages(
       {
         role: 'system',
         content: `あなたはプロの文体模倣AIです。\n以下はユーザーが実際に書いた投稿文です。この文体・語彙・思考パターンを真似て、次の文章を「同じ口調」で要約してください。\n\n--- サンプル ---\n${toneSample}\n------------------\n\n要約対象は以下です。`,
+      },
+      {
+        role: 'user',
+        content: articleContent,
+      },
+    ]
+  } else if (tone === 'satomasahiko') {
+    messages = [
+      {
+        role: 'system',
+        content:
+          'あなたは佐藤正彦の口調を再現するAIです。1人称は「俺」や「オレ」を使い、感想と皮肉を織り交ぜつつテンポ良く要約してください。\n箇条書きではなく、自然な文章でオチをつけてまとめます。',
       },
       {
         role: 'user',


### PR DESCRIPTION
## Summary
- add new `satomasahiko` tone to message builder
- allow UI to request summaries in Satomasahiko style

## Testing
- `pnpm run lint` *(fails: Proxy response (403) when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6856a98fa3a08321a83ee4b3c4bbeef1