### PR TITLE
Remove Satoh button and unify tone handling

### DIFF
--- a/app/api/summary/route.ts
+++ b/app/api/summary/route.ts
@@ -74,9 +74,9 @@ export async function GET(req: Request) {
       { status: 400 }
     );
   }
-  if (tone !== 'casual' && tone !== 'formal') {
+  if (tone !== 'casual' && tone !== 'formal' && tone !== 'custom') {
     return NextResponse.json(
-        { error: "無効なトーンが指定されました。casual または formal を指定してください。" },
+        { error: "無効なトーンが指定されました。casual、formal、または custom を指定してください。" },
         { status: 400 }
     );
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,7 +52,7 @@ export default function Home() {
 
 
   const handleSummarize = async (
-    selectedTone: "casual" | "formal" | "custom" | "satomasahiko"
+    selectedTone: "casual" | "formal" | "custom"
   ) => {
     if (!url) {
       alert("URLを入力してください");
@@ -298,7 +298,7 @@ export default function Home() {
           />
         </div>
 
-        <div className={`grid gap-3 mb-4 ${status === 'authenticated' ? 'grid-cols-4' : 'grid-cols-3'}`}>
+        <div className={`grid gap-3 mb-4 ${status === 'authenticated' ? 'grid-cols-3' : 'grid-cols-2'}`}>
           <button
             onClick={() => handleSummarize("casual")}
             className={`w-full px-4 py-2.5 bg-sky-500 text-white text-base rounded-md font-medium hover:bg-sky-600 active:bg-sky-700 transition-colors focus:outline-none focus:ring-1 focus:ring-sky-400 focus:ring-offset-1 ${
@@ -316,15 +316,6 @@ export default function Home() {
             disabled={isLoading}
           >
             {isLoading ? "処理中..." : "フォーマル"}
-          </button>
-          <button
-            onClick={() => handleSummarize("satomasahiko")}
-            className={`w-full px-4 py-2.5 bg-pink-500 text-white text-base rounded-md font-medium hover:bg-pink-600 active:bg-pink-700 transition-colors focus:outline-none focus:ring-1 focus:ring-pink-400 focus:ring-offset-1 ${
-              isLoading ? "opacity-50 cursor-not-allowed" : ""
-            }`}
-            disabled={isLoading}
-          >
-            {isLoading ? "処理中..." : "佐藤正彦風"}
           </button>
           {status === "authenticated" && (
             <button

--- a/lib/buildMessages.ts
+++ b/lib/buildMessages.ts
@@ -1,7 +1,7 @@
 import type { ChatCompletionRequestMessage } from 'openai'
 
 export function buildMessages(
-  tone: 'custom' | 'formal' | 'casual' | 'satomasahiko',
+  tone: 'custom' | 'formal' | 'casual',
   articleContent: string,
   toneSample?: string
 ): ChatCompletionRequestMessage[] {
@@ -12,18 +12,6 @@ export function buildMessages(
       {
         role: 'system',
         content: `あなたはプロの文体模倣AIです。\n以下はユーザーが実際に書いた投稿文です。この文体・語彙・思考パターンを真似て、次の文章を「同じ口調」で要約してください。\n\n--- サンプル ---\n${toneSample}\n------------------\n\n要約対象は以下です。`,
-      },
-      {
-        role: 'user',
-        content: articleContent,
-      },
-    ]
-  } else if (tone === 'satomasahiko') {
-    messages = [
-      {
-        role: 'system',
-        content:
-          'あなたは佐藤正彦の口調を再現するAIです。1人称は「俺」や「オレ」を使い、感想と皮肉を織り交ぜつつテンポ良く要約してください。\n箇条書きではなく、自然な文章でオチをつけてまとめます。',
       },
       {
         role: 'user',


### PR DESCRIPTION
## Summary
- remove "佐藤正彦風" button from the UI
- drop `satomasahiko` tone handling and rely on `custom`
- accept `custom` tone through GET API

## Testing
- `pnpm lint` *(fails: unable to fetch pnpm)*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ada565d88321922cbb78e3c4d78e