### PR TITLE
feat: add amazon product showcase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 
 # OpenAI
 OPENAI_API_KEY=your-openai-api-key
+
+# Amazon Product Advertising API
+AMAZON_ACCESS_KEY_ID=your-amazon-access-key
+AMAZON_SECRET_ACCESS_KEY=your-amazon-secret-key
+AMAZON_PARTNER_TAG=your-partner-tag-22
+# Optional overrides (defaults target Amazon.co.jp)
+# AMAZON_API_REGION=us-west-2
+# AMAZON_API_HOST=webservices.amazon.co.jp
+# AMAZON_MARKETPLACE=www.amazon.co.jp
 ```
 
-These variables are required for Google login and API requests to work correctly. After setting them, restart the development server.
+These variables are required for Google login and API requests to work correctly. The Amazon settings enable the product showcase that appears next to the summaries.
+After setting them, restart the development server.

--- a/app/api/amazon-products/route.ts
+++ b/app/api/amazon-products/route.ts
@@ -1,0 +1,285 @@
+import crypto from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+const DEFAULT_HOST = "webservices.amazon.co.jp";
+const DEFAULT_REGION = "us-west-2";
+const DEFAULT_MARKETPLACE = "www.amazon.co.jp";
+const SERVICE = "ProductAdvertisingAPI";
+const TARGET = "com.amazon.paapi5.v1.ProductAdvertisingAPIv1.SearchItems";
+
+interface AmazonProductResponseItem {
+  ASIN?: string;
+  DetailPageURL?: string;
+  Images?: {
+    Primary?: {
+      Medium?: {
+        URL?: string;
+      };
+    };
+  };
+  ItemInfo?: {
+    Title?: {
+      DisplayValue?: string;
+    };
+  };
+  Offers?: {
+    Listings?: Array<{
+      Price?: {
+        DisplayAmount?: string;
+        Amount?: number;
+        Currency?: string;
+      };
+    }>;
+  };
+  CustomerReviews?: {
+    StarRating?: number;
+    Count?: number;
+  };
+}
+
+interface AmazonProduct {
+  asin: string;
+  title: string;
+  url: string;
+  imageUrl?: string;
+  price?: string;
+  amount?: number;
+  currency?: string;
+  rating?: number;
+  reviewCount?: number;
+  matchedKeywords: string[];
+}
+
+interface SearchItemsPayload {
+  Keywords: string;
+  ItemCount: number;
+  PartnerTag: string;
+  PartnerType: "Associates";
+  Marketplace: string;
+  Resources: string[];
+  SearchIndex: string;
+}
+
+const buildSigningKey = (secretKey: string, dateStamp: string, region: string) => {
+  const kDate = crypto
+    .createHmac("sha256", "AWS4" + secretKey)
+    .update(dateStamp)
+    .digest();
+  const kRegion = crypto.createHmac("sha256", kDate).update(region).digest();
+  const kService = crypto.createHmac("sha256", kRegion).update(SERVICE).digest();
+  return crypto.createHmac("sha256", kService).update("aws4_request").digest();
+};
+
+const signRequest = (
+  body: string,
+  accessKeyId: string,
+  secretKey: string,
+  host: string,
+  region: string
+) => {
+  const method = "POST";
+  const canonicalUri = "/paapi5/searchitems";
+  const canonicalQuery = "";
+  const contentType = "application/json; charset=utf-8";
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\..+/g, "");
+  const dateStamp = amzDate.slice(0, 8);
+
+  const canonicalHeaders =
+    `content-type:${contentType}\n` +
+    `host:${host}\n` +
+    `x-amz-date:${amzDate}\n` +
+    `x-amz-target:${TARGET}\n`;
+  const signedHeaders = "content-type;host;x-amz-date;x-amz-target";
+  const payloadHash = crypto.createHash("sha256").update(body).digest("hex");
+  const canonicalRequest = [
+    method,
+    canonicalUri,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const credentialScope = `${dateStamp}/${region}/${SERVICE}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    crypto.createHash("sha256").update(canonicalRequest).digest("hex"),
+  ].join("\n");
+
+  const signingKey = buildSigningKey(secretKey, dateStamp, region);
+  const signature = crypto
+    .createHmac("sha256", signingKey)
+    .update(stringToSign)
+    .digest("hex");
+
+  const authorization =
+    `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, ` +
+    `SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return {
+    headers: {
+      "content-type": contentType,
+      "x-amz-date": amzDate,
+      "x-amz-target": TARGET,
+      Authorization: authorization,
+    },
+    path: canonicalUri,
+  };
+};
+
+const extractProducts = (
+  items: AmazonProductResponseItem[] = [],
+  keyword: string
+): AmazonProduct[] => {
+  return items
+    .filter((item) => item.ASIN && item.DetailPageURL)
+    .map((item) => {
+      const listing = item.Offers?.Listings?.[0];
+      const existingPrice = listing?.Price;
+
+      return {
+        asin: item.ASIN as string,
+        title: item.ItemInfo?.Title?.DisplayValue || "",
+        url: item.DetailPageURL as string,
+        imageUrl: item.Images?.Primary?.Medium?.URL,
+        price: existingPrice?.DisplayAmount,
+        amount: existingPrice?.Amount,
+        currency: existingPrice?.Currency,
+        rating: item.CustomerReviews?.StarRating,
+        reviewCount: item.CustomerReviews?.Count,
+        matchedKeywords: [keyword],
+      };
+    });
+};
+
+const mergeProducts = (collections: AmazonProduct[][]): AmazonProduct[] => {
+  const mergedMap = new Map<string, AmazonProduct>();
+
+  collections.flat().forEach((product) => {
+    const existing = mergedMap.get(product.asin);
+    if (existing) {
+      const keywords = new Set([
+        ...(existing.matchedKeywords || []),
+        ...product.matchedKeywords,
+      ]);
+      mergedMap.set(product.asin, {
+        ...existing,
+        matchedKeywords: Array.from(keywords),
+      });
+    } else {
+      mergedMap.set(product.asin, product);
+    }
+  });
+
+  return Array.from(mergedMap.values());
+};
+
+export async function POST(req: NextRequest) {
+  const {
+    AMAZON_ACCESS_KEY_ID,
+    AMAZON_SECRET_ACCESS_KEY,
+    AMAZON_PARTNER_TAG,
+    AMAZON_API_REGION,
+    AMAZON_API_HOST,
+    AMAZON_MARKETPLACE,
+  } = process.env;
+
+  const accessKeyId = AMAZON_ACCESS_KEY_ID;
+  const secretAccessKey = AMAZON_SECRET_ACCESS_KEY;
+  const partnerTag = AMAZON_PARTNER_TAG;
+
+  if (!accessKeyId || !secretAccessKey || !partnerTag) {
+    return NextResponse.json({
+      products: [],
+      error: "Amazon APIの資格情報が設定されていません。",
+    });
+  }
+
+  const host = AMAZON_API_HOST || DEFAULT_HOST;
+  const region = AMAZON_API_REGION || DEFAULT_REGION;
+  const marketplace = AMAZON_MARKETPLACE || DEFAULT_MARKETPLACE;
+
+  let payload: { keywords?: string[] };
+  try {
+    payload = await req.json();
+  } catch (error) {
+    return NextResponse.json(
+      {
+        products: [],
+        error: "リクエスト形式が正しくありません。",
+      },
+      { status: 400 }
+    );
+  }
+
+  const keywords = (payload.keywords || [])
+    .map((keyword) => (typeof keyword === "string" ? keyword.trim() : ""))
+    .filter((keyword) => keyword.length > 0)
+    .slice(0, 5);
+
+  if (keywords.length === 0) {
+    return NextResponse.json({ products: [] });
+  }
+
+  const baseBody: Omit<SearchItemsPayload, "Keywords"> = {
+    ItemCount: 6,
+    PartnerTag: partnerTag,
+    PartnerType: "Associates",
+    Marketplace: marketplace,
+    Resources: [
+      "Images.Primary.Medium",
+      "ItemInfo.Title",
+      "Offers.Listings.Price",
+      "CustomerReviews.Count",
+      "CustomerReviews.StarRating",
+    ],
+    SearchIndex: "All",
+  };
+
+  const results: AmazonProduct[][] = [];
+  for (const keyword of keywords) {
+    const body: SearchItemsPayload = {
+      ...baseBody,
+      Keywords: keyword,
+    };
+
+    const bodyString = JSON.stringify(body);
+    const { headers, path } = signRequest(
+      bodyString,
+      accessKeyId,
+      secretAccessKey,
+      host,
+      region
+    );
+
+    try {
+      const response = await fetch(`https://${host}${path}`, {
+        method: "POST",
+        headers,
+        body: bodyString,
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error("Amazon API error", response.status, errorBody);
+        continue;
+      }
+
+      const data = await response.json();
+      const items = data?.SearchResult?.Items as
+        | AmazonProductResponseItem[]
+        | undefined;
+      results.push(extractProducts(items, keyword));
+    } catch (error) {
+      console.error("Amazon API request failed", error);
+    }
+  }
+
+  const merged = mergeProducts(results).slice(0, 12);
+
+  return NextResponse.json({ products: merged });
+}

--- a/app/components/AmazonProductShowcase.tsx
+++ b/app/components/AmazonProductShowcase.tsx
@@ -1,0 +1,204 @@
+import Image from "next/image";
+import { useMemo } from "react";
+
+type AmazonProduct = {
+  asin: string;
+  title: string;
+  url: string;
+  imageUrl?: string;
+  price?: string;
+  amount?: number;
+  currency?: string;
+  rating?: number;
+  reviewCount?: number;
+  matchedKeywords?: string[];
+};
+
+type AmazonProductShowcaseProps = {
+  keywords: string[];
+  products: AmazonProduct[];
+  isLoading: boolean;
+  error: string | null;
+};
+
+const formatRating = (rating?: number) => {
+  if (!rating) return null;
+  return Math.round(rating * 10) / 10;
+};
+
+const renderStars = (rating?: number) => {
+  if (!rating) return null;
+  const rounded = Math.round(rating * 2) / 2;
+  const fullStars = Math.floor(rounded);
+  const hasHalf = rounded - fullStars >= 0.5;
+  const emptyStars = 5 - fullStars - (hasHalf ? 1 : 0);
+
+  return (
+    <span className="flex items-center gap-0.5 text-amber-500">
+      {Array.from({ length: fullStars }).map((_, idx) => (
+        <span key={`full-${idx}`}>★</span>
+      ))}
+      {hasHalf && <span className="text-amber-400">☆</span>}
+      {Array.from({ length: emptyStars }).map((_, idx) => (
+        <span key={`empty-${idx}`} className="text-slate-300">
+          ☆
+        </span>
+      ))}
+    </span>
+  );
+};
+
+const AmazonProductShowcase = ({
+  keywords,
+  products,
+  isLoading,
+  error,
+}: AmazonProductShowcaseProps) => {
+  const displayKeywords = useMemo(() => keywords.slice(0, 5), [keywords]);
+
+  const shouldRender = isLoading || error || products.length > 0 || keywords.length > 0;
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <aside className="w-full rounded-2xl bg-gradient-to-br from-amber-50 via-white to-sky-50 p-6 shadow-sm ring-1 ring-amber-100/60">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-amber-600">
+            おすすめアイテム
+          </p>
+          <h2 className="text-xl font-bold text-slate-700">
+            要約内容に合わせたAmazon商品
+          </h2>
+          <p className="mt-1 text-xs text-slate-500">
+            要約文から抽出したキーワードをもとに関連商品の候補をピックアップします。
+          </p>
+        </div>
+        {displayKeywords.length > 0 && (
+          <div className="hidden flex-wrap justify-end gap-1 text-xs text-amber-700 sm:flex">
+            {displayKeywords.map((keyword) => (
+              <span
+                key={keyword}
+                className="rounded-full bg-amber-100 px-3 py-1 font-medium"
+              >
+                #{keyword}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <div
+              key={idx}
+              className="flex animate-pulse flex-col rounded-xl border border-white/70 bg-white/60 p-4 shadow-sm"
+            >
+              <div className="mb-3 aspect-square w-full rounded-lg bg-slate-200" />
+              <div className="mb-2 h-3 rounded bg-slate-200" />
+              <div className="mb-1 h-3 w-3/4 rounded bg-slate-100" />
+              <div className="h-3 w-1/2 rounded bg-slate-100" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!isLoading && products.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-1">
+          {products.map((product) => (
+            <article
+              key={product.asin}
+              className="group flex h-full flex-col overflow-hidden rounded-xl border border-white/80 bg-white/80 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+            >
+              <div className="relative h-48 w-full overflow-hidden bg-slate-100">
+                {product.imageUrl ? (
+                  <Image
+                    src={product.imageUrl}
+                    alt={product.title}
+                    fill
+                    className="object-contain p-3 transition duration-300 group-hover:scale-105"
+                    sizes="(max-width: 1024px) 50vw, 280px"
+                  />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-sm text-slate-400">
+                    画像なし
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-1 flex-col p-4">
+                <h3
+                  className="text-sm font-semibold leading-snug text-slate-700"
+                  style={{
+                    display: "-webkit-box",
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }}
+                >
+                  {product.title || "商品名不明"}
+                </h3>
+
+                {product.price && (
+                  <p className="mt-2 text-lg font-bold text-rose-600">{product.price}</p>
+                )}
+
+                {(product.rating || product.reviewCount) && (
+                  <div className="mt-2 flex items-center gap-2 text-xs text-slate-500">
+                    {renderStars(product.rating)}
+                    {product.rating && (
+                      <span className="font-semibold text-slate-600">
+                        {formatRating(product.rating)}
+                      </span>
+                    )}
+                    {typeof product.reviewCount === "number" && (
+                      <span>({product.reviewCount.toLocaleString()}件の評価)</span>
+                    )}
+                  </div>
+                )}
+
+                {product.matchedKeywords && product.matchedKeywords.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-1 text-[11px] text-amber-700">
+                    {product.matchedKeywords.map((keyword) => (
+                      <span key={keyword} className="rounded-full bg-amber-100 px-2 py-0.5">
+                        #{keyword}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                <div className="mt-auto pt-4">
+                  <a
+                    href={product.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-amber-600"
+                  >
+                    Amazonで見る
+                    <span aria-hidden>→</span>
+                  </a>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {!isLoading && products.length === 0 && !error && (
+        <div className="rounded-xl border border-dashed border-amber-200 bg-white/60 p-6 text-sm text-slate-500">
+          要約結果が表示されると、関連するAmazon商品をこちらに掲載します。
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-4 text-sm font-medium text-rose-600">{error}</p>
+      )}
+    </aside>
+  );
+};
+
+export type { AmazonProduct };
+export default AmazonProductShowcase;


### PR DESCRIPTION
## Summary
- implement a signed Amazon Product Advertising API route that fetches related items from summary keywords
- add an Amazon product showcase component and integrate it into the main page layout alongside summaries
- document required Amazon API environment variables and add a basic ESLint config for non-interactive linting

## Testing
- pnpm lint *(fails: ESLint package cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce04d633908321ae107fc692f721ca