### PR TITLE
Fix Amazon PA-API request headers

### DIFF
--- a/app/api/amazon-products/route.ts
+++ b/app/api/amazon-products/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs";
+
 import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -332,6 +334,8 @@ const signRequest = (
       "content-type": contentType,
       "x-amz-date": amzDate,
       "x-amz-target": TARGET,
+      host,
+      "User-Agent": "AIKijiYoyaku/1.0",
       Authorization: authorization,
     },
     path: canonicalUri,


### PR DESCRIPTION
## Summary
- force the amazon products route to run on the Node.js runtime so required headers can be set
- include host and User-Agent headers in the signed PA-API request to avoid signature mismatches

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3baf8f14832187e70c162636093e