### PR TITLE
Send payload hash header for Amazon Product API requests

### DIFF
--- a/app/api/amazon-products/route.ts
+++ b/app/api/amazon-products/route.ts
@@ -334,7 +334,7 @@ const signRequest = (
       "content-type": contentType,
       "x-amz-date": amzDate,
       "x-amz-target": TARGET,
-      host: host,
+      "x-amz-content-sha256": payloadHash,
       "User-Agent": "AIKijiYoyaku/1.0",
       Authorization: authorization,
     },


### PR DESCRIPTION
## Summary
- include the request payload hash in the x-amz-content-sha256 header when calling the Amazon Product Advertising API
- rely on fetch to add the Host header while keeping the signature unchanged

## Testing
- pnpm lint *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68ce40e9b5d08321b7cee0ebc12a6341