### PR TITLE
Add amazon-paapi dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@radix-ui/react-tooltip": "1.1.6",
     "@next-auth/supabase-adapter": "latest",
     "autoprefixer": "^10.4.20",
+    "amazon-paapi": "^3.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",


### PR DESCRIPTION
## Summary
- add the amazon-paapi package to package.json so that it matches pnpm-lock.yaml

## Testing
- pnpm install *(fails: ERR_PNPM_FETCH_403 GET https://registry.npmjs.org/amazon-paapi)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6004a25483218d208fee7c2986a1