### PR TITLE
Add vercel install command override

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "vercel build",
+  "installCommand": "pnpm install --no-frozen-lockfile"
+}


### PR DESCRIPTION
## Summary
- add a `vercel.json` configuration file at the repository root
- force Vercel installs to use `pnpm install --no-frozen-lockfile` to avoid lockfile drift

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf450000408321a1c4456f0e8b4120