### PR TITLE
Expand Amazon API resources for search results

### DIFF
--- a/app/api/amazon-products/route.ts
+++ b/app/api/amazon-products/route.ts
@@ -443,7 +443,13 @@ export async function POST(req: NextRequest) {
     PartnerTag: partnerTag,
     PartnerType: "Associates",
     Marketplace: marketplace,
-    Resources: ["ItemInfo.Title"],
+    Resources: [
+      "Images.Primary.Medium",
+      "ItemInfo.Title",
+      "Offers.Listings.Price",
+      "CustomerReviews.Count",
+      "CustomerReviews.StarRating",
+    ],
     SearchIndex: "All",
   };
 


### PR DESCRIPTION
## Summary
- expand the requested Amazon Product Advertising API resources so search responses include images, price, and review metadata

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cf562fdf788321b5a371e2423fa33b