### PR TITLE
Add Amazon PAAPI debug endpoint and improve diagnostics

### DIFF
--- a/app/api/_debug-paapi/route.ts
+++ b/app/api/_debug-paapi/route.ts
@@ -1,0 +1,33 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const {
+    AMAZON_ACCESS_KEY_ID,
+    AMAZON_SECRET_ACCESS_KEY,
+    AMAZON_PARTNER_TAG,
+    AMAZON_MARKETPLACE,
+  } = process.env;
+
+  const id = (AMAZON_ACCESS_KEY_ID || "").trim();
+  const secret = (AMAZON_SECRET_ACCESS_KEY || "").trim();
+  const tag = (AMAZON_PARTNER_TAG || "").trim();
+  const marketplace = (AMAZON_MARKETPLACE || "www.amazon.co.jp").trim();
+
+  return NextResponse.json({
+    // ここだけで個人情報は出さない（プレフィックスだけ）
+    hasId: Boolean(id),
+    idPrefix: id ? id.slice(0, 4) : null,
+    hasSecret: Boolean(secret),
+    secretLen: secret ? secret.length : 0,
+    hasTag: Boolean(tag),
+    tag,
+    marketplace,
+    notes: [
+      "hasId/hasSecret/hasTag が全て true になること",
+      "tag は -22 を含む JP 用トラッキングID",
+      "marketplace は www.amazon.co.jp でOK",
+    ],
+  });
+}

--- a/app/api/amazon-products/route.ts
+++ b/app/api/amazon-products/route.ts
@@ -1,13 +1,7 @@
 export const runtime = "nodejs";
 
-import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
-
-const DEFAULT_HOST = "webservices.amazon.co.jp";
-const DEFAULT_REGION = "us-west-2";
-const DEFAULT_MARKETPLACE = "www.amazon.co.jp";
-const SERVICE = "ProductAdvertisingAPI";
-const TARGET = "com.amazon.paapi5.v1.ProductAdvertisingAPIv1.SearchItems";
+import AmazonPaapi from "amazon-paapi";
 
 interface AmazonProductResponseItem {
   ASIN?: string;
@@ -52,236 +46,110 @@ interface AmazonProduct {
   matchedKeywords: string[];
 }
 
-interface SearchItemsPayload {
-  Keywords: string;
-  ItemCount: number;
-  PartnerTag: string;
-  PartnerType: "Associates";
-  Marketplace: string;
-  Resources: string[];
-  SearchIndex: string;
-}
-
-const buildSigningKey = (secretKey: string, dateStamp: string, region: string) => {
-  const kDate = crypto
-    .createHmac("sha256", "AWS4" + secretKey)
-    .update(dateStamp)
-    .digest();
-  const kRegion = crypto.createHmac("sha256", kDate).update(region).digest();
-  const kService = crypto.createHmac("sha256", kRegion).update(SERVICE).digest();
-  return crypto.createHmac("sha256", kService).update("aws4_request").digest();
-};
-
-const normalizeHost = (host: string) =>
-  host.replace(/^https?:\/\//, "").replace(/\/+$/, "");
-
-const signRequest = (
-  body: string,
-  accessKeyId: string,
-  secretKey: string,
-  host: string,
-  region: string
-) => {
-  const method = "POST";
-  const canonicalUri = "/paapi5/searchitems";
-  const canonicalQuery = "";
-  const contentType = "application/json; charset=UTF-8";
-  const now = new Date();
-  const amzDate = now.toISOString().replace(/[:-]|\..+/g, "");
-  const dateStamp = amzDate.slice(0, 8);
-
-  const payloadHash = crypto.createHash("sha256").update(body).digest("hex");
-  const canonicalHeaders =
-    `content-type:${contentType}\n` +
-    `host:${host}\n` +
-    `x-amz-content-sha256:${payloadHash}\n` +
-    `x-amz-date:${amzDate}\n` +
-    `x-amz-target:${TARGET}\n`;
-  const signedHeaders =
-    "content-type;host;x-amz-content-sha256;x-amz-date;x-amz-target";
-  const canonicalRequest = [
-    method,
-    canonicalUri,
-    canonicalQuery,
-    canonicalHeaders,
-    signedHeaders,
-    payloadHash,
-  ].join("\n");
-
-  const credentialScope = `${dateStamp}/${region}/${SERVICE}/aws4_request`;
-  const stringToSign = [
-    "AWS4-HMAC-SHA256",
-    amzDate,
-    credentialScope,
-    crypto.createHash("sha256").update(canonicalRequest).digest("hex"),
-  ].join("\n");
-
-  const signingKey = buildSigningKey(secretKey, dateStamp, region);
-  const signature = crypto
-    .createHmac("sha256", signingKey)
-    .update(stringToSign)
-    .digest("hex");
-
-  const authorization =
-    `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, ` +
-    `SignedHeaders=${signedHeaders}, Signature=${signature}`;
-
-  return {
-    headers: {
-      "content-type": contentType,
-      Accept: "application/json",
-      "x-amz-date": amzDate,
-      "x-amz-target": TARGET,
-      "x-amz-content-sha256": payloadHash,
-      "User-Agent": "AIKijiYoyaku/1.0 (+support@aizubrandhall.jp)",
-      Authorization: authorization,
-    },
-    path: canonicalUri,
-  };
-};
-
-const extractProducts = (
-  items: AmazonProductResponseItem[] = [],
-  keyword: string
-): AmazonProduct[] => {
-  return items
-    .filter((item) => item.ASIN && item.DetailPageURL)
-    .map((item) => {
-      const listing = item.Offers?.Listings?.[0];
-      const existingPrice = listing?.Price;
-
-      return {
-        asin: item.ASIN as string,
-        title: item.ItemInfo?.Title?.DisplayValue || "",
-        url: item.DetailPageURL as string,
-        imageUrl: item.Images?.Primary?.Medium?.URL,
-        price: existingPrice?.DisplayAmount,
-        amount: existingPrice?.Amount,
-        currency: existingPrice?.Currency,
-        rating: item.CustomerReviews?.StarRating,
-        reviewCount: item.CustomerReviews?.Count,
-        matchedKeywords: [keyword],
-      };
-    });
-};
-
-const mergeProducts = (collections: AmazonProduct[][]): AmazonProduct[] => {
-  const mergedMap = new Map<string, AmazonProduct>();
-
-  collections.flat().forEach((product) => {
-    const existing = mergedMap.get(product.asin);
-    if (existing) {
-      const keywords = new Set([
-        ...(existing.matchedKeywords || []),
-        ...product.matchedKeywords,
-      ]);
-      mergedMap.set(product.asin, {
-        ...existing,
-        matchedKeywords: Array.from(keywords),
-      });
-    } else {
-      mergedMap.set(product.asin, product);
-    }
-  });
-
-  return Array.from(mergedMap.values());
-};
-
 export async function POST(req: NextRequest) {
+  const id = (process.env.AMAZON_ACCESS_KEY_ID || "").trim();
+  const secret = (process.env.AMAZON_SECRET_ACCESS_KEY || "").trim();
+  const tag = (process.env.AMAZON_PARTNER_TAG || "").trim();
+  const marketplace = (process.env.AMAZON_MARKETPLACE || "www.amazon.co.jp").trim();
+
+  if (!id || !secret || !tag) {
+    return NextResponse.json(
+      { products: [], error: "Amazon APIの資格情報が不足しています。" },
+      { status: 400 }
+    );
+  }
+
+  let payload: { keywords?: string[] } = {};
   try {
-    const payload = await req.json();
+    payload = await req.json();
+  } catch {}
 
-    const keywords = (payload?.keywords || [])
-      .map((keyword: unknown) => (typeof keyword === "string" ? keyword.trim() : ""))
-      .filter((keyword: string) => keyword.length > 0)
-      .slice(0, 5);
+  const keywords = (payload.keywords ?? [])
+    .filter((k): k is string => typeof k === "string")
+    .map((k) => k.trim())
+    .filter(Boolean)
+    .slice(0, 5);
 
-    if (keywords.length === 0) {
-      return NextResponse.json({ products: [] });
-    }
+  if (!keywords.length) {
+    return NextResponse.json({ products: [] });
+  }
 
-    const {
-      AMAZON_ACCESS_KEY_ID,
-      AMAZON_SECRET_ACCESS_KEY,
-      AMAZON_PARTNER_TAG,
-      AMAZON_API_REGION,
-      AMAZON_API_HOST,
-      AMAZON_MARKETPLACE,
-    } = process.env;
+  const commonParameters = {
+    AccessKey: id,
+    SecretKey: secret,
+    PartnerTag: tag,
+    PartnerType: "Associates",
+    Marketplace: marketplace,
+  } as const;
 
-    if (!AMAZON_ACCESS_KEY_ID || !AMAZON_SECRET_ACCESS_KEY || !AMAZON_PARTNER_TAG) {
-      throw new Error("Amazon API credentials are not configured.");
-    }
+  const resources = [
+    "Images.Primary.Medium",
+    "ItemInfo.Title",
+    "Offers.Listings.Price",
+    "CustomerReviews.Count",
+    "CustomerReviews.StarRating",
+  ];
 
-    const host = normalizeHost(AMAZON_API_HOST || DEFAULT_HOST);
-    const region = AMAZON_API_REGION || DEFAULT_REGION;
-    const marketplace = AMAZON_MARKETPLACE || DEFAULT_MARKETPLACE;
+  const collected: AmazonProduct[] = [];
 
-    const baseBody: Omit<SearchItemsPayload, "Keywords"> = {
-      ItemCount: 5,
-      PartnerTag: AMAZON_PARTNER_TAG,
-      PartnerType: "Associates",
-      Marketplace: marketplace,
-      Resources: [
-        "Images.Primary.Medium",
-        "ItemInfo.Title",
-        "Offers.Listings.Price",
-        "CustomerReviews.Count",
-        "CustomerReviews.StarRating",
-      ],
+  for (const kw of keywords) {
+    const requestParameters = {
+      Keywords: kw,
+      ItemCount: 6,
+      Resources: resources,
       SearchIndex: "All",
     };
 
-    const results: AmazonProduct[][] = [];
+    try {
+      const res: any = await AmazonPaapi.SearchItems(commonParameters, requestParameters);
+      const items: AmazonProductResponseItem[] = res?.SearchResult?.Items ?? [];
 
-    for (const keyword of keywords) {
-      const body: SearchItemsPayload = {
-        ...baseBody,
-        Keywords: keyword,
-      };
-
-      const bodyString = JSON.stringify(body);
-      const { headers, path } = signRequest(
-        bodyString,
-        AMAZON_ACCESS_KEY_ID,
-        AMAZON_SECRET_ACCESS_KEY,
-        host,
-        region
-      );
-
-      const response = await fetch(`https://${host}${path}`, {
-        method: "POST",
-        headers,
-        body: bodyString,
-        cache: "no-store",
-      });
-
-      if (!response.ok) {
-        const errorBody = await response.text();
-        throw new Error(
-          `Amazon API error ${response.status}: ${errorBody || response.statusText}`
-        );
+      for (const it of items) {
+        if (!it?.ASIN || !it?.DetailPageURL) continue;
+        const listing = it?.Offers?.Listings?.[0];
+        collected.push({
+          asin: it.ASIN,
+          title: it?.ItemInfo?.Title?.DisplayValue ?? "",
+          url: it.DetailPageURL,
+          imageUrl: it?.Images?.Primary?.Medium?.URL,
+          price: listing?.Price?.DisplayAmount,
+          amount: listing?.Price?.Amount,
+          currency: listing?.Price?.Currency,
+          rating: it?.CustomerReviews?.StarRating,
+          reviewCount: it?.CustomerReviews?.Count,
+          matchedKeywords: [kw],
+        });
       }
-
-      const data = await response.json();
-      const items = data?.SearchResult?.Items as
-        | AmazonProductResponseItem[]
-        | undefined;
-      results.push(extractProducts(items, keyword));
+    } catch (e: any) {
+      const body = e?.body || e?.message || String(e);
+      console.error("PAAPI SearchItems error:", body);
+      return NextResponse.json(
+        {
+          products: [],
+          error: "Amazon API error",
+          details: body,
+          partnerTagUsed: tag,
+          marketplace,
+        },
+        { status: 502 }
+      );
     }
-
-    const merged = mergeProducts(results).slice(0, 12);
-
-    return NextResponse.json({ products: merged });
-  } catch (err: unknown) {
-    const error = err as { message?: string } | string;
-    console.error("Amazon API error:", err);
-    return NextResponse.json(
-      {
-        error: "Amazon API error",
-        details: typeof error === "string" ? error : error?.message,
-      },
-      { status: 500 }
-    );
   }
+
+  const map = new Map<string, AmazonProduct>();
+  for (const product of collected) {
+    const existing = map.get(product.asin);
+    if (!existing) {
+      map.set(product.asin, product);
+      continue;
+    }
+    map.set(product.asin, {
+      ...existing,
+      matchedKeywords: Array.from(
+        new Set([...(existing.matchedKeywords ?? []), ...product.matchedKeywords])
+      ),
+    });
+  }
+
+  return NextResponse.json({ products: Array.from(map.values()).slice(0, 12) });
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "vaul": "^0.9.6",
     "zod": "^3.24.1",
     "next-auth": "latest",
-    "@supabase/supabase-js": "^2.44.1"
+    "@supabase/supabase-js": "^2.44.1",
+    "amazon-paapi": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- add a temporary PAAPI debug endpoint to inspect runtime environment variables
- trim Amazon credentials and marketplace variables before calling PAAPI
- surface raw Amazon API error details to aid troubleshooting and record partner tag usage
- add the amazon-paapi dependency used by the new implementation

## Testing
- pnpm lint *(fails: ESLint not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a4007a2c8321a5a370bb401bdcbe