### PR TITLE
Add required Amazon API parameters

### DIFF
--- a/app/api/amazon-products/route.ts
+++ b/app/api/amazon-products/route.ts
@@ -74,6 +74,15 @@ export async function POST(req: NextRequest) {
       PartnerType: "Associates",
       Marketplace: MARKETPLACE,
       Operation: "SearchItems",
+      SearchIndex: "All",
+      ItemCount: 6,
+      Resources: [
+        "Images.Primary.Medium",
+        "ItemInfo.Title",
+        "Offers.Listings.Price",
+        "CustomerReviews.Count",
+        "CustomerReviews.StarRating",
+      ],
     };
     const body = JSON.stringify(bodyObj);
     const payloadHash = sha256Hex(body);


### PR DESCRIPTION
## Summary
- include SearchIndex, ItemCount, and Resources in Amazon PA-API SearchItems request body
- ensure the API call satisfies required parameters so Amazon returns product data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1fbd8645c8321b46093b322b8b858