### PR TITLE
Harden API access and URL fetching

### DIFF
--- a/app/api/admin-auth/route.ts
+++ b/app/api/admin-auth/route.ts
@@ -1,5 +1,6 @@
 // /app/api/admin-auth/route.ts ver.1
 import { NextRequest, NextResponse } from 'next/server';
+import { getAdminAuthCookieName, getAdminAuthToken } from '@/lib/adminAuth';
 
 export const runtime = 'edge';
 
@@ -13,7 +14,20 @@ export async function POST(req: NextRequest) {
     }
 
     if (password === correctPassword) {
-      return NextResponse.json({ success: true });
+      const response = NextResponse.json({ success: true });
+      const token = getAdminAuthToken();
+
+      response.cookies.set({
+        name: getAdminAuthCookieName(),
+        value: token,
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 6,
+      });
+
+      return response;
     } else {
       return NextResponse.json({ error: '認証失敗' }, { status: 401 });
     }

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -13,11 +13,10 @@ export const authOptions: NextAuthOptions = {
   ],
   callbacks: {
     async session({ session, token }) {
-      // 既存のデータベースIDと一致させる
-      if (session?.user) {
-        session.user.id = '065c6f7d-8f75-485c-a77c-bba493443e1e';
+      if (session?.user && token?.sub) {
+        session.user.id = token.sub;
       }
-      return session
+      return session;
     },
   },
   pages: {

--- a/app/api/fetch-ogp/route.ts
+++ b/app/api/fetch-ogp/route.ts
@@ -1,9 +1,14 @@
 // /app/api/fetch-ogp/route.ts ver.1
 import { NextRequest, NextResponse } from 'next/server';
+import { isAdminRequest } from '@/lib/adminAuth';
+import { assertSafeUrl } from '@/lib/ssrf';
 
-export const runtime = 'edge';
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
+  if (!isAdminRequest(req)) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
   try {
     const { url } = await req.json();
 
@@ -11,8 +16,13 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'URLが必要です' }, { status: 400 });
     }
 
+    const safetyCheck = await assertSafeUrl(url);
+    if (!safetyCheck.ok) {
+      return NextResponse.json({ error: safetyCheck.error }, { status: 400 });
+    }
+
     // URLからHTMLを取得
-    const response = await fetch(url, {
+    const response = await fetch(safetyCheck.url.toString(), {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
       },

--- a/app/api/manual-products/metadata/route.ts
+++ b/app/api/manual-products/metadata/route.ts
@@ -1,5 +1,7 @@
 // /app/api/manual-products/metadata/route.ts
 import { NextRequest, NextResponse } from "next/server";
+import { isAdminRequest } from "@/lib/adminAuth";
+import { assertSafeUrl } from "@/lib/ssrf";
 
 export const runtime = "nodejs";
 
@@ -60,6 +62,9 @@ const formatPrice = (price?: string | number, currency?: string) => {
 };
 
 export async function GET(req: NextRequest) {
+  if (!isAdminRequest(req)) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
   const { searchParams } = new URL(req.url);
   const targetUrl = searchParams.get("url");
 
@@ -68,7 +73,12 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const response = await fetch(targetUrl, {
+    const safetyCheck = await assertSafeUrl(targetUrl);
+    if (!safetyCheck.ok) {
+      return NextResponse.json({ error: safetyCheck.error }, { status: 400 });
+    }
+
+    const response = await fetch(safetyCheck.url.toString(), {
       headers: {
         "Accept-Language": "ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7",
         "User-Agent": "Mozilla/5.0 (compatible; ProductMetaFetcher/1.0)",

--- a/app/api/manual-products/route.ts
+++ b/app/api/manual-products/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse, NextRequest } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { isAdminRequest } from '@/lib/adminAuth';
+import { enforceSameOriginForMutation } from '@/lib/originGuard';
 
 // Supabaseクライアントの作成
 const supabase = createClient(
@@ -31,6 +32,8 @@ export async function GET() {
 
 // データ保存（POST）
 export async function POST(req: NextRequest) {
+  const blocked = enforceSameOriginForMutation(req);
+  if (blocked) return blocked;
   if (!isAdminRequest(req)) {
     return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
   }

--- a/app/api/manual-products/route.ts
+++ b/app/api/manual-products/route.ts
@@ -1,6 +1,7 @@
 // /app/api/manual-products/route.ts ver.1
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isAdminRequest } from '@/lib/adminAuth';
 
 // Supabaseクライアントの作成
 const supabase = createClient(
@@ -29,7 +30,10 @@ export async function GET() {
 }
 
 // データ保存（POST）
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
+  if (!isAdminRequest(req)) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
   try {
     const body = await req.json();
     const { products } = body;

--- a/app/api/registered-links/route.ts
+++ b/app/api/registered-links/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { isAdminRequest } from '@/lib/adminAuth';
+import { enforceSameOriginForMutation } from '@/lib/originGuard';
 
 const supabase = createClient(
   process.env.SUPABASE_URL!,
@@ -30,6 +31,8 @@ export async function GET() {
 
 // リンク追加（POST）
 export async function POST(req: NextRequest) {
+  const blocked = enforceSameOriginForMutation(req);
+  if (blocked) return blocked;
   if (!isAdminRequest(req)) {
     return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
   }
@@ -69,6 +72,8 @@ export async function POST(req: NextRequest) {
 
 // リンク削除（DELETE）
 export async function DELETE(req: NextRequest) {
+  const blocked = enforceSameOriginForMutation(req);
+  if (blocked) return blocked;
   if (!isAdminRequest(req)) {
     return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
   }

--- a/app/api/registered-links/route.ts
+++ b/app/api/registered-links/route.ts
@@ -1,6 +1,7 @@
 // /app/api/registered-links/route.ts ver.1
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isAdminRequest } from '@/lib/adminAuth';
 
 const supabase = createClient(
   process.env.SUPABASE_URL!,
@@ -29,6 +30,9 @@ export async function GET() {
 
 // リンク追加（POST）
 export async function POST(req: NextRequest) {
+  if (!isAdminRequest(req)) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
   try {
     const body = await req.json();
     const { url, title, description, ogp_image_url } = body;
@@ -65,6 +69,9 @@ export async function POST(req: NextRequest) {
 
 // リンク削除（DELETE）
 export async function DELETE(req: NextRequest) {
+  if (!isAdminRequest(req)) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
   try {
     const { searchParams } = new URL(req.url);
     const id = searchParams.get('id');

--- a/app/api/sns/generate-text/route.ts
+++ b/app/api/sns/generate-text/route.ts
@@ -1,5 +1,9 @@
 // /app/api/sns/generate-text/route.ts ver.5
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+
+export const runtime = "nodejs";
 
 type Platform = "x" | "instagram" | "story" | "threads";
 
@@ -104,6 +108,11 @@ async function callGeminiAPI(prompt: string, retryCount: number = 0): Promise<st
 
 export async function POST(request: NextRequest) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
     const body = await request.json();
     const { originalText, platforms, linkUrl } = body as {
       originalText: string;

--- a/app/api/summary/route.ts
+++ b/app/api/summary/route.ts
@@ -1,8 +1,11 @@
 // /app/api/summary/route.ts ver.22 - Gemini 2.5 Flash (標準版) 採用
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { assertSafeUrl } from "@/lib/ssrf";
 import { buildMessagesForGemini } from "@/lib/buildMessages";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 const MAX_INPUT_CHAR_LENGTH = 15000;
 
@@ -14,7 +17,12 @@ async function fetchUrlContent(url: string): Promise<{
   error?: string 
 }> {
   try {
-    const response = await fetch(url, {
+    const safetyCheck = await assertSafeUrl(url);
+    if (!safetyCheck.ok) {
+      return { content: null, truncated: false, originalLength: 0, error: safetyCheck.error };
+    }
+
+    const response = await fetch(safetyCheck.url.toString(), {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
       },
@@ -109,6 +117,11 @@ async function callGeminiAPI(prompt: string): Promise<string> {
 // POSTハンドラ
 export async function POST(req: Request) {
   try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
     const body = await req.json();
     const { url, tone, toneSample } = body;
 

--- a/lib/adminAuth.ts
+++ b/lib/adminAuth.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from "next/server";
+
+const ADMIN_AUTH_COOKIE = "admin_auth";
+
+export const getAdminAuthToken = () => {
+  const token = process.env.ADMIN_AUTH_TOKEN;
+  if (!token) {
+    throw new Error("Missing ADMIN_AUTH_TOKEN environment variable.");
+  }
+  return token;
+};
+
+export const getAdminAuthCookieName = () => ADMIN_AUTH_COOKIE;
+
+export const isAdminRequest = (req: NextRequest) => {
+  const token = getAdminAuthToken();
+  const cookieValue = req.cookies.get(ADMIN_AUTH_COOKIE)?.value;
+  return cookieValue === token;
+};

--- a/lib/originGuard.ts
+++ b/lib/originGuard.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function getAllowedOrigins(req: NextRequest): string[] {
+  const env = process.env.APP_ORIGIN;
+  const list = env
+    ? env.split(',').map(s => s.trim()).filter(Boolean)
+    : [];
+
+  const host =
+    req.headers.get('x-forwarded-host') ??
+    req.headers.get('host') ??
+    '';
+
+  const proto =
+    req.headers.get('x-forwarded-proto') ??
+    (process.env.NODE_ENV === 'development' ? 'http' : 'https');
+
+  const derived = host ? `${proto}://${host}` : '';
+
+  const allowed = [
+    ...list,
+    ...(derived ? [derived] : []),
+  ];
+
+  if (process.env.NODE_ENV === 'development') {
+    allowed.push('http://localhost:3000');
+    allowed.push('http://127.0.0.1:3000');
+  }
+
+  return Array.from(new Set(allowed.map(o => o.replace(/\/+$/, ''))));
+}
+
+/**
+ * For mutation requests, require Origin header and enforce same-origin/allowlist.
+ * Returns NextResponse(403) if blocked, otherwise null.
+ */
+export function enforceSameOriginForMutation(req: NextRequest): NextResponse | null {
+  const method = req.method.toUpperCase();
+  const isMutation = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method);
+  if (!isMutation) return null;
+
+  const origin = (req.headers.get('origin') || '').replace(/\/+$/, '');
+  if (!origin) {
+    return NextResponse.json(
+      { error: 'Forbidden: missing Origin' },
+      { status: 403 }
+    );
+  }
+
+  const allowed = getAllowedOrigins(req);
+  if (!allowed.includes(origin)) {
+    return NextResponse.json(
+      { error: 'Forbidden: bad Origin', origin, allowed },
+      { status: 403 }
+    );
+  }
+
+  return null;
+}

--- a/lib/ssrf.ts
+++ b/lib/ssrf.ts
@@ -1,0 +1,84 @@
+import dns from "node:dns/promises";
+import net from "node:net";
+
+const isPrivateIpv4 = (ip: string) => {
+  const [a, b] = ip.split(".").map((octet) => Number(octet));
+  if ([a, b].some((octet) => Number.isNaN(octet))) return true;
+  return (
+    a === 10 ||
+    a === 127 ||
+    a === 0 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+};
+
+const isPrivateIpv6 = (ip: string) => {
+  const normalized = ip.toLowerCase();
+  return (
+    normalized === "::1" ||
+    normalized === "::" ||
+    normalized.startsWith("fc") ||
+    normalized.startsWith("fd") ||
+    normalized.startsWith("fe80")
+  );
+};
+
+const isPrivateIp = (ip: string) => {
+  const ipVersion = net.isIP(ip);
+  if (ipVersion === 4) return isPrivateIpv4(ip);
+  if (ipVersion === 6) return isPrivateIpv6(ip);
+  return true;
+};
+
+const isDisallowedHostname = (hostname: string) => {
+  const lower = hostname.toLowerCase();
+  return (
+    lower === "localhost" ||
+    lower.endsWith(".localhost") ||
+    lower.endsWith(".local") ||
+    lower.endsWith(".internal")
+  );
+};
+
+export const assertSafeUrl = async (rawUrl: string) => {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (error) {
+    return { ok: false, error: "Invalid URL format" };
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    return { ok: false, error: "Only http/https URLs are allowed" };
+  }
+
+  if (isDisallowedHostname(parsed.hostname)) {
+    return { ok: false, error: "Hostname is not allowed" };
+  }
+
+  const ipVersion = net.isIP(parsed.hostname);
+  if (ipVersion) {
+    if (isPrivateIp(parsed.hostname)) {
+      return { ok: false, error: "Private IPs are not allowed" };
+    }
+    return { ok: true, url: parsed };
+  }
+
+  try {
+    const records = await dns.lookup(parsed.hostname, { all: true });
+    if (records.length === 0) {
+      return { ok: false, error: "Hostname could not be resolved" };
+    }
+    for (const record of records) {
+      if (isPrivateIp(record.address)) {
+        return { ok: false, error: "Hostname resolves to a private IP" };
+      }
+    }
+  } catch (error) {
+    return { ok: false, error: "Hostname could not be resolved" };
+  }
+
+  return { ok: true, url: parsed };
+};


### PR DESCRIPTION
### Motivation

- Protect admin-only mutation endpoints and the admin login flow by adding server-side cookie-based admin auth checks. 
- Prevent SSRF and unsafe server-side fetches by validating and resolving target URLs before fetching. 
- Require real authenticated user sessions for AI-backed endpoints and ensure session IDs reflect the provider `sub` value.

### Description

- Add `lib/adminAuth.ts` with `getAdminAuthToken`, `getAdminAuthCookieName` and `isAdminRequest`, and set the admin auth cookie in `app/api/admin-auth/route.ts` when login succeeds. 
- Add `lib/ssrf.ts` implementing `assertSafeUrl` to disallow private/internal hosts and IPs and use it in `app/api/fetch-ogp/route.ts`, `app/api/manual-products/metadata/route.ts`, and `app/api/summary/route.ts` to validate/resolved URLs before `fetch`. 
- Guard admin-only endpoints by calling `isAdminRequest` in `app/api/registered-links/route.ts` and `app/api/manual-products/route.ts`, and require authenticated sessions via `getServerSession` for `app/api/summary/route.ts` and `app/api/sns/generate-text/route.ts`, switching those routes to `runtime: nodejs` where needed. 
- Replace the hardcoded NextAuth user ID with `session.user.id = token.sub`, and set the admin cookie `secure` flag conditionally (`secure: process.env.NODE_ENV === 'production'`).

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc644589083218d6240179b805662)